### PR TITLE
fix(jdma): send form_ids to setTop250 instead of product_ids

### DIFF
--- a/actions/grist-procedures-urls/index.js
+++ b/actions/grist-procedures-urls/index.js
@@ -111,8 +111,8 @@ const getGristUrls = async (
         Authorization: `Bearer ${jdma_api_key}`,
       },
       body: JSON.stringify({
-        product_ids: response
-          .map((record) => record.fields[field_names.id])
+        form_ids: response
+          .map((record) => record.fields[field_names.form_id])
           .filter((id) => !isNaN(parseInt(id))),
       }),
     });


### PR DESCRIPTION
## Context

The `isTop250` flag is moving from the **product** to the **form** on jedonnemonavis. As a result, the `setTop250` open-api endpoint now expects **form ids** rather than product ids.

## Change

In `actions/grist-procedures-urls/index.js`, the POST body to `/api/open-api/setTop250` now:

- sends the ids under the `form_ids` key (was `product_ids`)
- sources them from `record.fields["Dashlord_ID_JDMA_Formulaire"]` (`field_names.form_id`) instead of `record.fields["Dashlord_ID_JDMA"]` (`field_names.id`)

The non-numeric filter (`.filter((id) => !isNaN(parseInt(id)))`) is unchanged, so procedures without a form id are dropped just as procedures without a product id were before. The endpoint URL and auth are unchanged.

```diff
       body: JSON.stringify({
-        product_ids: response
-          .map((record) => record.fields[field_names.id])
+        form_ids: response
+          .map((record) => record.fields[field_names.form_id])
           .filter((id) => !isNaN(parseInt(id))),
       }),
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)